### PR TITLE
🩹 CRA 문제로 인한 프록시 문제 해결

### DIFF
--- a/frontend/.env
+++ b/frontend/.env
@@ -1,0 +1,2 @@
+# 배포시 설정 필요
+DANGEROUSLY_DISABLE_HOST_CHECK=true

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,20 +1,8 @@
-import React, {useEffect, useState} from 'react';
+import React, { useEffect, useState } from 'react';
 import axios from 'axios';
 
 function App() {
-  const [hello, setHello] = useState('')
-
-  useEffect(() => {
-    axios.get('/api/hello')
-        .then(response => setHello(response.data))
-        .catch(error => console.log(error))
-  }, []);
-
-  return (
-      <div>
-        백엔드에서 가져온 데이터입니다 : {hello}
-      </div>
-  );
+  return <div>백엔드에서 가져온 데이터입니다 </div>;
 }
 
 export default App;


### PR DESCRIPTION
DANGEROUSLY_DISABLE_HOST_CHECK 환경 변수
.env 파일에서 DANGEROUSLY_DISABLE_HOST_CHECK=true를 설정하면 일반적으로 인식된 호스트의 요청만 허용되는지 확인하는 보안 검사를 비활성화하도록 Webpack 개발 서버에 지시합니다. 이는 주로 브라우저가 일반적으로 액세스할 수 없는 로컬 서버에 액세스하도록 속일 수 있는 DNS 리바인딩과 같은 일부 유형의 네트워크 공격을 방지하기 위한 보안 기능입니다.

즉 보안 기능을 우회했을뿐 해결은 아님 나중에 호스트 설정을 해줘야함 